### PR TITLE
Resolvido Bug Created_at e Updated_at

### DIFF
--- a/src/Model/Mysql.php
+++ b/src/Model/Mysql.php
@@ -199,7 +199,7 @@ abstract class Mysql extends MysqlDataBase implements DataBase
     {
         $date = date('Y-m-d H:i:s');
         switch ($action) {
-            case 'Cac\Model\Model::update':
+            case 'Cac\SimpleBase\Model\Mysql::update':
                 $attributes['updated_at'] = $date;
                 break;
             default:


### PR DESCRIPTION
Os campos created_at e updated_at, estavam trocados.

O updated_at nao atualizava, por não encontrar o diretorio 'Cac\SimpleBase\Model\Mysql::update' , então entraca no default do switch e no fim o created_at recebia a data atualizada.